### PR TITLE
Enhanced structure queue processing performance, updated forge, applied patch to entity wander A.I.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,7 @@ dependencies {
 }
 
 def version_minecraft="1.12.2"
-def version_forge="14.23.5.2838"
+def version_forge="14.23.5.2847"
 def version_mappings="stable_39"
 def curseforge_id="248278"
 def curseforge_release_type="release"

--- a/src/main/java/com/asx/mdx/MDXModule.java
+++ b/src/main/java/com/asx/mdx/MDXModule.java
@@ -6,6 +6,7 @@ import com.asx.mdx.lib.client.DebugToolsRenderer;
 import com.asx.mdx.lib.client.gui.GUIElementTracker;
 import com.asx.mdx.lib.client.gui.notifications.NotifierModule;
 import com.asx.mdx.lib.client.model.loaders.DummyModelLoader;
+import com.asx.mdx.lib.hotfix.JoinWorldEvent;
 import com.asx.mdx.lib.util.Game;
 import com.asx.mdx.lib.util.system.SystemInfo;
 import com.asx.mdx.lib.world.StructureGenerationHandler;
@@ -44,6 +45,7 @@ public class MDXModule
         WebModule.startWebServer();
         SystemInfo.INSTANCE.runtimeTasks();
         Game.registerEventHandler(StructureGenerationHandler.INSTANCE);
+        Game.registerEventHandler(JoinWorldEvent.INSTANCE);
     }
 
     @SideOnly(Side.CLIENT)

--- a/src/main/java/com/asx/mdx/lib/client/entityfx/EntityBloodFX.java
+++ b/src/main/java/com/asx/mdx/lib/client/entityfx/EntityBloodFX.java
@@ -29,10 +29,10 @@ public class EntityBloodFX extends Particle
     private int                          bobTimer;
     private boolean                      glow;
 
-    public EntityBloodFX(World worldIn, double posX, double posY, double posZ, int color, boolean glow)
+    public EntityBloodFX(World worldIn, double posX, double posY, double posZ, int color, int maxAge, boolean glow)
     {
         super(worldIn, posX, posY, posZ, 0, 0, 0);
-        this.particleMaxAge = ((60 * 20) * 2) + ((this.rand.nextInt(30 * 20)));
+        this.particleMaxAge = maxAge + this.rand.nextInt((maxAge / 4) + 1);
         this.glow = glow;
         this.particleGravity = 0.36F;
         this.particleScale = (this.rand.nextFloat() * 0.5F + 0.5F);

--- a/src/main/java/com/asx/mdx/lib/hotfix/EntityAIWanderPatch.java
+++ b/src/main/java/com/asx/mdx/lib/hotfix/EntityAIWanderPatch.java
@@ -1,0 +1,99 @@
+package com.asx.mdx.lib.hotfix;
+
+import javax.annotation.Nullable;
+
+import net.minecraft.entity.EntityCreature;
+import net.minecraft.entity.ai.EntityAIBase;
+import net.minecraft.entity.ai.RandomPositionGenerator;
+import net.minecraft.util.math.Vec3d;
+
+public class EntityAIWanderPatch extends EntityAIBase
+{
+    protected final EntityCreature entity;
+    protected double x;
+    protected double y;
+    protected double z;
+    protected final double speed;
+    protected int executionChance;
+    protected boolean mustUpdate;
+
+    public EntityAIWanderPatch(EntityCreature creatureIn, double speedIn)
+    {
+        this(creatureIn, speedIn, 120);
+    }
+
+    public EntityAIWanderPatch(EntityCreature creatureIn, double speedIn, int chance)
+    {
+        this.entity = creatureIn;
+        this.speed = speedIn;
+        this.executionChance = chance;
+        this.setMutexBits(1);
+    }
+
+    /**
+     * Returns whether the EntityAIBase should begin execution.
+     */
+    public boolean shouldExecute()
+    {
+        if (!this.mustUpdate)
+        {
+            if (this.entity.getRNG().nextInt(this.executionChance) != 0)
+            {
+                return false;
+            }
+        }
+
+        Vec3d vec3d = this.getPosition();
+
+        if (vec3d == null)
+        {
+            return false;
+        }
+        else
+        {
+            this.x = vec3d.x;
+            this.y = vec3d.y;
+            this.z = vec3d.z;
+            this.mustUpdate = false;
+            return true;
+        }
+    }
+
+    @Nullable
+    protected Vec3d getPosition()
+    {
+        return RandomPositionGenerator.findRandomTarget(this.entity, 10, 7);
+    }
+
+    /**
+     * Returns whether an in-progress EntityAIBase should continue executing
+     */
+    public boolean shouldContinueExecuting()
+    {
+        return !this.entity.getNavigator().noPath();
+    }
+
+    /**
+     * Execute a one shot task or start executing a continuous task
+     */
+    public void startExecuting()
+    {
+        this.entity.getNavigator().tryMoveToXYZ(this.x, this.y, this.z, this.speed);
+    }
+
+    /**
+     * Makes task to bypass chance
+     */
+    public void makeUpdate()
+    {
+        this.mustUpdate = true;
+    }
+
+    /**
+     * Changes task random possibility for execution
+     */
+    public void setExecutionChance(int newchance)
+    {
+        this.executionChance = newchance;
+    }
+}

--- a/src/main/java/com/asx/mdx/lib/hotfix/JoinWorldEvent.java
+++ b/src/main/java/com/asx/mdx/lib/hotfix/JoinWorldEvent.java
@@ -1,0 +1,20 @@
+package com.asx.mdx.lib.hotfix;
+
+import net.minecraft.entity.EntityCreature;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraftforge.event.entity.EntityJoinWorldEvent;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+
+public class JoinWorldEvent
+{
+    public static final JoinWorldEvent INSTANCE = new JoinWorldEvent();
+
+    @SubscribeEvent
+    public void onEntityJoinWorld(EntityJoinWorldEvent event)
+    {
+        if (!(event.getEntity() instanceof EntityPlayer) && event.getEntity() instanceof EntityCreature)
+        {
+            ((EntityCreature) event.getEntity()).tasks.addTask(1, new EntityAIWanderPatch(((EntityCreature) event.getEntity()), 0.8D));
+        }
+    }
+}

--- a/src/main/java/com/asx/mdx/lib/world/StructureGenerationHandler.java
+++ b/src/main/java/com/asx/mdx/lib/world/StructureGenerationHandler.java
@@ -1,6 +1,7 @@
 package com.asx.mdx.lib.world;
 
 import java.util.ArrayList;
+import java.util.Iterator;
 
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import net.minecraftforge.fml.common.gameevent.TickEvent;
@@ -10,17 +11,18 @@ public class StructureGenerationHandler
     public static final StructureGenerationHandler INSTANCE          = new StructureGenerationHandler();
     private ArrayList<Structure>                   structuresInQueue = new ArrayList<Structure>();
 
-    @SuppressWarnings("unchecked")
     @SubscribeEvent
     public void serverTick(TickEvent.ServerTickEvent event)
     {
-        ArrayList<Structure> structures = (ArrayList<Structure>) structuresInQueue.clone();
+        Iterator<Structure> iter = structuresInQueue.iterator();
 
-        for (Structure structure : structures)
+        while (iter.hasNext())
         {
+            Structure structure = iter.next();
+
             if (structure.process())
             {
-                this.structuresInQueue.remove(structure);
+                iter.remove();
             }
         }
     }

--- a/src/main/java/com/asx/mdx/lib/world/StructureGenerationHandler.java
+++ b/src/main/java/com/asx/mdx/lib/world/StructureGenerationHandler.java
@@ -5,11 +5,10 @@ import java.util.ArrayList;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import net.minecraftforge.fml.common.gameevent.TickEvent;
 
-
 public class StructureGenerationHandler
 {
-    public static final StructureGenerationHandler INSTANCE = new StructureGenerationHandler();
-    private ArrayList<Structure> structuresInQueue = new ArrayList<Structure>();
+    public static final StructureGenerationHandler INSTANCE          = new StructureGenerationHandler();
+    private ArrayList<Structure>                   structuresInQueue = new ArrayList<Structure>();
 
     @SuppressWarnings("unchecked")
     @SubscribeEvent
@@ -25,7 +24,7 @@ public class StructureGenerationHandler
             }
         }
     }
-    
+
     public static void addStructureToQueue(Structure structure)
     {
         getStructuresInQueue().add(structure);

--- a/src/main/java/com/asx/mdx/lib/world/entity/player/inventory/Inventories.java
+++ b/src/main/java/com/asx/mdx/lib/world/entity/player/inventory/Inventories.java
@@ -169,13 +169,18 @@ public class Inventories
     {
         if (!player.capabilities.isCreativeMode || force)
         {
-            int i = getSlotFor(player.inventory, item);
+            int i = getSlotFor(player.inventory, item, false);
+            boolean isOffhand = false;
 
             if (i < 0)
             {
-                return false;
+            	i = getSlotFor(player.inventory, item, true);
+            	isOffhand = true;
+            	if(i < 0)
+            		return false;
             }
-            else
+            
+            if(!isOffhand)
             {
                 player.inventory.mainInventory.get(i).shrink(1);
                 
@@ -183,8 +188,15 @@ public class Inventories
                 {
                     player.inventory.mainInventory.set(i, ItemStack.EMPTY);
                 }
-
-                return true;
+            }
+            else
+            {
+            	player.inventory.offHandInventory.get(i).shrink(1);
+                
+                if (player.inventory.offHandInventory.get(i).getCount() <= 0)
+                {
+                    player.inventory.offHandInventory.set(i, ItemStack.EMPTY);
+                }
             }
         }
 
@@ -198,14 +210,16 @@ public class Inventories
      * @param item - The item to search for.
      * @return The index of the slot.
      */
-    public static int getSlotFor(InventoryPlayer inventory, Item item)
+    public static int getSlotFor(InventoryPlayer inventory, Item item, boolean checkOffhand)
     {
         for (int i = 0; i < inventory.mainInventory.size(); ++i)
         {
-            if (inventory.mainInventory.get(i) != null && inventory.mainInventory.get(i).getItem() == item)
+            if (!checkOffhand && inventory.mainInventory.get(i) != null && inventory.mainInventory.get(i).getItem() == item)
             {
                 return i;
             }
+            else if(checkOffhand && inventory.offHandInventory.get(i) != null && inventory.offHandInventory.get(i).getItem() == item)
+            	return i;
         }
 
         return -1;


### PR DESCRIPTION
This PR includes the following patches/fixes:
- An enhancement to the performance of structure processing. This was previously cloning the structure queue before doing work on it. This has been corrected to use iterators.
- Forge has been updated to 14.23.5.2847 (1.12.2).
- Applied a patch that fixes entity wandering A.I for 1.12.2.
-- Reasoning: In 1.12.2, entity A.I has been rendered broken by Mojang due to their neglect of an entity's "idle time". Entity wandering A.I depends on the idle time of the entity, and because the idle time is never reset, the entities will wander once and then never wander again. This PR applies an injection of new wandering A.I code that disregards idle time, but still has the same effect as Mojang's wandering A.I. This injection is applied to all living entities (except players) as soon as they join the world, so vanilla and modded entities alike should now wander properly.