### PR TITLE
Fixes for item lighting and inappropriate A.I injection

### DIFF
--- a/src/main/java/com/asx/mdx/lib/client/util/OpenGL.java
+++ b/src/main/java/com/asx/mdx/lib/client/util/OpenGL.java
@@ -289,7 +289,10 @@ public class OpenGL
 
     public static void enableStandardItemLighting()
     {
-        RenderHelper.enableStandardItemLighting();
+        GlStateManager.enableLighting();
+        GlStateManager.enableLight(0);
+        GlStateManager.enableLight(1);
+        GlStateManager.enableColorMaterial();
     }
 
     public static void disableStandardItemLighting()

--- a/src/main/java/com/asx/mdx/lib/hotfix/JoinWorldEvent.java
+++ b/src/main/java/com/asx/mdx/lib/hotfix/JoinWorldEvent.java
@@ -1,6 +1,7 @@
 package com.asx.mdx.lib.hotfix;
 
 import net.minecraft.entity.EntityCreature;
+import net.minecraft.entity.SharedMonsterAttributes;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraftforge.event.entity.EntityJoinWorldEvent;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
@@ -14,7 +15,14 @@ public class JoinWorldEvent
     {
         if (!(event.getEntity() instanceof EntityPlayer) && event.getEntity() instanceof EntityCreature)
         {
-            ((EntityCreature) event.getEntity()).tasks.addTask(1, new EntityAIWanderPatch(((EntityCreature) event.getEntity()), 0.8D));
+            EntityCreature entity = (EntityCreature) event.getEntity();
+            
+            double entitySpeed = entity.getEntityAttribute(SharedMonsterAttributes.MOVEMENT_SPEED).getBaseValue();
+            
+            if(entitySpeed != 0)
+            {
+                entity.tasks.addTask(1, new EntityAIWanderPatch(entity, entitySpeed));
+            }
         }
     }
 }


### PR DESCRIPTION
- Fixed item rendering causing lighting for everything else (entities, GUI items, etc.) to break.
- The wandering A.I injection fix should no longer inject into entities that have no speed (aren't meant to move).