### PR TITLE
Read subprocess output before waiting for its termination

### DIFF
--- a/src/main/java/com/asx/mdx/common/system/SystemInfo.java
+++ b/src/main/java/com/asx/mdx/common/system/SystemInfo.java
@@ -50,7 +50,6 @@ public class SystemInfo
 
             if (process != null)
             {
-                process.waitFor();
                 BufferedReader buffer = new BufferedReader(new InputStreamReader(process.getInputStream()));
                 String line = "";
 
@@ -62,6 +61,7 @@ public class SystemInfo
                     }
                 }
 
+                process.waitFor();
                 buffer.close();
             }
 
@@ -76,7 +76,6 @@ public class SystemInfo
 
             if (process != null)
             {
-                process.waitFor();
                 BufferedReader buffer = new BufferedReader(new InputStreamReader(process.getInputStream()));
                 String line = "";
 
@@ -95,6 +94,7 @@ public class SystemInfo
                         }
                     }
 
+                    process.waitFor();
                     buffer.close();
                 }
             }


### PR DESCRIPTION
This fixes a bug where mdxlib would prevent the server from starting if /proc/cpuinfo was too long.
It seems like cat was waiting for mdxlib to read the output buffer while mdxlib was waiting for the process to terminate before reading anything.

To fix this, I moved the wait for call behind the output processing, which solved the problem.
I haven't tested if this was also a problem on other operating systems, but if it is this change would prevent that.