### PR TITLE
set process to null after reading the output

### DIFF
--- a/src/main/java/com/asx/mdx/common/system/SystemInfo.java
+++ b/src/main/java/com/asx/mdx/common/system/SystemInfo.java
@@ -63,6 +63,7 @@ public class SystemInfo
                 }
 
                 buffer.close();
+                process = null;
             }
 
             switch (osType)


### PR DESCRIPTION
This prevents a warning where mdxlib would try to read the process output again during the memory section on non-windows systems